### PR TITLE
Fix dockerfile image name with tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM archlinux/base
+FROM archlinux:base
 
 RUN pacman -Syu --noconfirm  icedtea-web libxext libxrender libxtst fontconfig ttf-dejavu
 


### PR DESCRIPTION
# Fix le nom de l'image docker

L'image a été renommé en faveur d'utiliser un `tag` plutôt qu'un séparation dans le nom.

<img width="889" alt="image" src="https://user-images.githubusercontent.com/25652765/120568125-45245900-c3e1-11eb-95a9-2429a45f9ba8.png">

<img width="1173" alt="image" src="https://user-images.githubusercontent.com/25652765/120568139-4d7c9400-c3e1-11eb-9b1a-e1e48c0d2f39.png">
